### PR TITLE
Replace submission form with link to open Github issue

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3244,7 +3244,6 @@ input, select, textarea {
 			#footer > .inner .copyright {
 				width: 100%;
 				padding: 0;
-				margin-top: 5em;
 				list-style: none;
 				font-size: 0.8em;
 				color: rgba(88, 88, 88, 0.5);

--- a/contributors.html
+++ b/contributors.html
@@ -139,22 +139,9 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="#">
-									<div class="fields">
-										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
-										</div>
-										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
-										</div>
-										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
-										</div>
-									</div>
-									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
-									</ul>
-								</form>
+								<p>If you have a feature request, are experiencing any issues, or want to report a bug, please <a
+										href="https://github.com/20jasper/100Devs-Statistics-Project/issues/" target="_blank">open a Github
+										issue</a>.</p>
 							</section>
 							<section>
 								<h2>Follow</h2>

--- a/elements.html
+++ b/elements.html
@@ -369,22 +369,9 @@ print 'It took ' + i + ' iterations to sort the deck.';</code></pre>
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="#">
-									<div class="fields">
-										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
-										</div>
-										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
-										</div>
-										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
-										</div>
-									</div>
-									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
-									</ul>
-								</form>
+								<p>If you have a feature request, are experiencing any issues, or want to report a bug, please <a
+										href="https://github.com/20jasper/100Devs-Statistics-Project/issues/" target="_blank">open a Github
+										issue</a>.</p>
 							</section>
 							<section>
 								<h2>Follow</h2>

--- a/generic.html
+++ b/generic.html
@@ -64,22 +64,9 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="#">
-									<div class="fields">
-										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
-										</div>
-										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
-										</div>
-										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
-										</div>
-									</div>
-									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
-									</ul>
-								</form>
+								<p>If you have a feature request, are experiencing any issues, or want to report a bug, please <a
+										href="https://github.com/20jasper/100Devs-Statistics-Project/issues/" target="_blank">open a Github
+										issue</a>.</p>
 							</section>
 							<section>
 								<h2>Follow</h2>

--- a/index.html
+++ b/index.html
@@ -198,22 +198,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="#">
-									<div class="fields">
-										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
-										</div>
-										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
-										</div>
-										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
-										</div>
-									</div>
-									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
-									</ul>
-								</form>
+								<p>If you have a feature request or want to report a bug, please <a href="https://github.com/20jasper/100Devs-Statistics-Project/issues/" target="_blank">open a Github issue</a>.</p>
 							</section>
 							<section>
 								<h2>Follow</h2>

--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<p>If you have a feature request or want to report a bug, please <a href="https://github.com/20jasper/100Devs-Statistics-Project/issues/" target="_blank">open a Github issue</a>.</p>
+								<p>If you have a feature request, are experiencing any issues, or want to report a bug, please <a href="https://github.com/20jasper/100Devs-Statistics-Project/issues/" target="_blank">open a Github issue</a>.</p>
 							</section>
 							<section>
 								<h2>Follow</h2>


### PR DESCRIPTION
List of changes:
- Removed the submission form 
- Added copy and a link to open a github issue under "Get in touch" 
- Removed margin top to reduce the spacing

Are we still using the generic and element pages? We should remove those if we're not using those pages. If anyone can confirm, I can remove them in this PR.

Ticket: https://github.com/20jasper/100Devs-Statistics-Project/issues/19

